### PR TITLE
Rev version of hello-build orb for faster builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hello-build: circleci/hello-build@0.0.8
+  hello-build: circleci/hello-build@0.0.10
   secret_scan: eddiewebb/secret_scan@0.0.3
 
 workflows:


### PR DESCRIPTION
Using the latest hello-build orb starts significantly faster (on the order of 20 seconds down to ~1).

Not other functionality should be impacted. 